### PR TITLE
Update .gitignore to remove Cairo feature headers

### DIFF
--- a/gfx/cairo/cairo/src/.gitignore
+++ b/gfx/cairo/cairo/src/.gitignore
@@ -10,8 +10,6 @@ Makefile.am.features
 *.lo
 *.loT
 *.pc
-cairo-features.h
-cairo-supported-features.h
 cairo.def
 *.i
 *.s


### PR DESCRIPTION
Removed specific Cairo feature header files from .gitignore.